### PR TITLE
✨ feat: 앨범 페이지 이미지 로딩 스켈레톤 UI 추가

### DIFF
--- a/src/components/BowlCard.tsx
+++ b/src/components/BowlCard.tsx
@@ -3,9 +3,11 @@ interface BowlCardProps {
   image: string | null;
   date: string;
   onClick: () => void;
+  isRevealed?: boolean;
+  onImageLoad?: () => void;
 }
 
-function BowlCard({ image, onClick }: BowlCardProps) {
+function BowlCard({ image, onClick, isRevealed = true, onImageLoad }: BowlCardProps) {
   return (
     <div
       className="aspect-square w-full cursor-pointer overflow-hidden border-3 shadow-md transition-all duration-200 hover:scale-110 hover:shadow-lg"
@@ -14,7 +16,14 @@ function BowlCard({ image, onClick }: BowlCardProps) {
       }}
     >
       {image ? (
-        <img src={image} alt="생성된 요거트볼" className="h-full w-full object-cover" />
+        <>
+          {!isRevealed && (
+            <div className="relative h-full w-full overflow-hidden bg-gray-200">
+              <div className="animate-shimmer absolute inset-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
+            </div>
+          )}
+          <img src={image} alt="생성된 요거트볼" className={`h-full w-full object-cover ${isRevealed ? "" : "hidden"}`} onLoad={onImageLoad} />
+        </>
       ) : (
         <div className="flex h-full w-full items-center justify-center bg-gray-200">
           <span className="text-gray-400">이미지 없음</span>

--- a/src/index.css
+++ b/src/index.css
@@ -102,6 +102,18 @@ body {
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+@theme {
+  --animate-shimmer: shimmer 1.5s infinite;
+  @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+}
+
 :root {
   --radius: 0.625rem;
   --background: hsl(0 0% 100%);

--- a/src/pages/BowlCardListPage.tsx
+++ b/src/pages/BowlCardListPage.tsx
@@ -1,7 +1,7 @@
 import { useConvexAuth, usePaginatedQuery } from "convex/react";
 import BowlCard from "../components/BowlCard";
 import { api } from "../../convex/_generated/api";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { BottomNav } from "../components/BottomNav";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
@@ -16,12 +16,36 @@ function BowlCardListPage() {
   const navigate = useNavigate();
   const { isAuthenticated } = useConvexAuth();
 
+  // 이미지 로딩 상태 추적
+  const [loadedIds, setLoadedIds] = useState<Set<string>>(new Set());
+  const [revealIds, setRevealedIds] = useState<Set<string>>(new Set());
+
+  // 함수를 캐싱(리렌더링 방지)
+  const handleImageLoad = useCallback((id: string) => {
+    setLoadedIds((prev) => new Set(prev).add(id));
+  }, []);
+
   // 로그인 안되어 있는 경우 메인 페이지로 팅겨냄
   useEffect(() => {
     if (!isAuthenticated) {
       navigate("/");
     }
   }, [isAuthenticated, navigate]);
+
+  // 스켈레톤 한 페이지씩 보여주기 위함
+  useEffect(() => {
+    // 공개 안된 이미지들
+    const unrevealed = results.filter((b) => b.url && !revealIds.has(b._id));
+
+    // 그 중 전부 로드가 되면
+    if (unrevealed.length > 0 && unrevealed.every((b) => loadedIds.has(b._id))) {
+      setRevealedIds((prev) => {
+        const next = new Set(prev);
+        unrevealed.forEach((b) => next.add(b._id));
+        return next;
+      });
+    }
+  }, [results, loadedIds, revealIds]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -59,9 +83,17 @@ function BowlCardListPage() {
       {results.length === 0 && <div className="col-span-2 py-10 text-center text-gray-500">저장된 요거트볼이 없습니다</div>}
 
       <div className="grid grid-cols-2 gap-4 p-4 pt-4">
-        {results?.map((bowl) => {
-          return <BowlCard key={bowl._id} id={bowl._id} image={bowl.url} date={new Date(bowl.createdAt).toLocaleString()} onClick={() => navigate(`/detail/${bowl._id}`)} />;
-        })}
+        {results?.map((bowl) => (
+          <BowlCard
+            key={bowl._id}
+            id={bowl._id}
+            image={bowl.url}
+            date={new Date(bowl.createdAt).toLocaleString()}
+            onClick={() => navigate(`/detail/${bowl._id}`)}
+            isRevealed={revealIds.has(bowl._id)}
+            onImageLoad={() => handleImageLoad(bowl._id)}
+          />
+        ))}
         {status === "LoadingMore" && <LoadingOverlay text="로딩 중..." />}
       </div>
       <div ref={observerRef} aria-hidden="true" />


### PR DESCRIPTION
## #️⃣ 연관 이슈

fixes #이슈번호

## ✔️진행 사항
  - 앨범 페이지 이미지 로딩 스켈레톤 UI 구현                                          
  - 배치 단위 이미지 로딩 완료 시 일괄 표시 기능 추가 

## 🪄작업 내용
  - BowlCard 컴포넌트에 isRevealed, onImageLoad props 추가                            
  - shimmer 애니메이션 스켈레톤 적용 (index.css)                                      
  - BowlCardListPage에서 loadedIds, revealIds 상태로 이미지 로딩 추적                 
  - 한 페이지(배치) 내 모든 이미지가 로드되면 한꺼번에 표시되도록 구현

## 🖼️ 결과 화면 


## 🤖 AI 코드 리뷰

