### PR TITLE
perf: 커서 토핑 위치 업데이트를 left/top에서 transform으로 변경

### DIFF
--- a/src/components/YogurtBowl.tsx
+++ b/src/components/YogurtBowl.tsx
@@ -32,8 +32,7 @@ export const YogurtBowl = memo(({ ref }: YogurtBowlProps) => {
     const handleMouseMove = (e: MouseEvent) => {
       mousePosRef.current = { x: e.clientX, y: e.clientY }; // 위치 저장
       if (cursorImageRef.current) {
-        cursorImageRef.current.style.left = `${e.clientX - 10}px`;
-        cursorImageRef.current.style.top = `${e.clientY - 10}px`;
+        cursorImageRef.current.style.transform = `translate(${e.clientX - 10}px, ${e.clientY - 10}px)`;
       }
     };
 
@@ -47,8 +46,7 @@ export const YogurtBowl = memo(({ ref }: YogurtBowlProps) => {
   // 토핑 이미지가 바뀔 때 현재 마우스 위치로 초기화
   useEffect(() => {
     if (cursorImageRef.current) {
-      cursorImageRef.current.style.left = `${mousePosRef.current.x - 10}px`;
-      cursorImageRef.current.style.top = `${mousePosRef.current.y - 10}px`;
+      cursorImageRef.current.style.transform = `translate(${mousePosRef.current.x - 10}px, ${mousePosRef.current.y - 10}px)`;
     }
   }, [selectedTopping]);
 
@@ -135,6 +133,8 @@ export const YogurtBowl = memo(({ ref }: YogurtBowlProps) => {
           className="z-50 h-[75px] w-[75px] object-contain"
           style={{
             position: "fixed",
+            left: 0,
+            top: 0,
             pointerEvents: "none", // 마우스 이벤트 차단 방지
           }}
           ref={cursorImageRef} // ref 토핑위치 연결


### PR DESCRIPTION
 ## Summary                                                                                                              
  - 커서 추적 토핑 이미지의 위치 업데이트 방식을 `left`/`top`에서 `transform: translate()`로 변경
  - `left`/`top`은 매번 레이아웃 재계산(reflow)을 트리거하지만, `transform`은 컴포지터 레이어에서만 처리되어 렌더링 성능
  개선
  - 커서 이미지에 `left: 0, top: 0` 추가하여 `transform` 기준점을 뷰포트 좌상단으로 고정

  ## Test plan
  - [x] 토핑 선택 후 마우스 커서 옆에 토핑 이미지가 정상적으로 따라다니는지 확인
  - [x] 토핑 변경 시 커서 위치에 즉시 반영되는지 확인
  - [x] 요거트볼 클릭하여 토핑 배치가 정상 동작하는지 확인
